### PR TITLE
Change styling on header and cover photo; social media link hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,31 +141,31 @@
 
 			<div class="button">
 				<a href="https://www.facebook.com/PGHpawngrabbers/">
-					<img src = "facebooklogo.png" width="30" height="30">
+					<img src = "facebooklogo.png" alt="Facebook" width="30" height="30">
 				</a>
 			</div>
 
 			<div class="button">
 				<a href="https://twitter.com/pghpawngrabbers?lang=en">
-					<img src = "twitterlogo.png" width="30" height="30">
+					<img src = "twitterlogo.png" alt="Twitter" width="30" height="30">
 				</a>
 			</div>
 
 			<div class="button">
 				<a href="https://www.twitch.tv/pghpawngrabbers">
-					<img src = "twitchlogo.png" width="30" height="30">
+					<img src = "twitchlogo.png" alt="Twitch" width="30" height="30">
 				</a>
 			</div>
 
 			<div class="button">
 				<a href="https://www.youtube.com/channel/UC0HxgtAm7xXKNN_zl5_hJLA">
-					<img src = "youtubelogo.png" width="30" height="30">
+					<img src = "youtubelogo.png" alt="Youtube" width="30" height="30">
 				</a>
 			</div>
             
             <div class="button">
 				<a href="https://www.instagram.com/pghpawngrabbers/">
-					<img src = "insta.png" width="30" height="30">
+					<img src = "insta.png" alt="Instagram" width="30" height="30">
 				</a>
 			</div>
 

--- a/index.html
+++ b/index.html
@@ -13,21 +13,19 @@
 	<div class="container">
 
 		<div class="header">
-			<div id="top-logo">
-				<h1>
-				<div>
-				<a href="#">
-					<img src="Pawngrabbers%20Main.png" width="50" height="50">
-				</a>
+			<div class="title-div">
+				<div id="top-logo">
+					<a href="#">
+						<img src="Pawngrabbers%20Main.png" width="50" height="50">
+					</a>
 				</div>
-				</h1>
+				<div id="title-text">Pittsburgh Pawngrabbers</div>
 			</div>
 
-			<div id="title-text">Pittsburgh Pawngrabbers</div>
 
 			<div id="nav-bar">
 				<ul>
-                    <li><a href="bio.html">Bios</a></li>
+					<li><a href="bio.html">Bios</a></li>
 					<!--<li>
                         <div class="dropdown">
                             <button class="dropbtn">Home</button>
@@ -39,34 +37,34 @@
                         </div>
                     </li>-->
 					<li><a href="stream2.html">Stream</a></li>
-					<li><a href="blog.html">Blog</a></li>
+					<li><a href="blog/blog.html">Blog</a></li>
 					<li><a href="https://shop.spreadshirt.com/pghpawngrabbers">Shop</a></li>
 				</ul>
 			</div>
-			<div class = "clr"></div>
+			<!-- <div class="clr"></div> -->
 		</div>
 
+		<!--comment -->
 		<script>
-			$(function() {
-    			var header = $(".header");
-    			$(window).scroll(function() {    
-        			var scroll = $(window).scrollTop();
-        			if (scroll >= 70) {
-            			header.addClass("scrolled");
-        		}   else {
-        				header.removeClass("scrolled");
-            	}
-    		});
+			$(function () {
+				var header = $(".header");
+				$(window).scroll(function () {
+					var scroll = $(window).scrollTop();
+					if (scroll >= 70) {
+						header.addClass("scrolled");
+					} else {
+						header.removeClass("scrolled");
+					}
+				});
 
 			});
 		</script>
 
 		<!-- ################### HEADER ENDS ##################-->
-        
-		<div style = "padding-bottom:70px"></div>
-		<div class ="big-image">
+
+		<div class="cover-photo-div">
 			<a href="#">
-				<img src="TwitchCoverPGH.jpg" alt="My Sample Image" width="1024" height="300">
+				<img class="cover-photo" src="TwitchCoverPGH.jpg" alt="Cover Photo">
 			</a>
 		</div>
         

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -57,8 +57,8 @@ a:hover{
 
 /*there has to be a better way to do this */
 
-.button:hover{
-	background:black;
+.button img:hover{
+	/* background:black; */
 	color:#fff;
 	transform:scale(1.3);
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -71,15 +71,20 @@ a:hover{
 	position:fixed;
 	top:0;
 	width:80%;
-	transition:1s;
+    transition:1s;
+    display: flex;
+    justify-content: space-between;
 }
 
-/*.big-image{
-    position:fixed;
-    overflow: hidden;
-    top:auto;
-    width:80%;
-}*/
+.cover-photo-div {
+    margin-top: 80px;
+    /* max-height: 324.26px; */
+}
+
+.cover-photo {
+    max-width: 100%;
+    display:block;
+}
 
 .scrolled{
 	background-color:darkgrey;
@@ -87,20 +92,27 @@ a:hover{
 }
 
 #top-logo{
-	float:left;
-	width:7%;
-	box-sizing:border-box;
-	padding:5px
+	/* float:left; */
+	/* width:7%; */
+	/* box-sizing:border-box; */
+    padding:5px;
+    display: inline-block;
 }
 
 #title-text{
 	padding-left:15px;
-	padding-top:18px;
-	float:left;
+	/* padding-top:18px; */
+	/* float:left; */
     font-family: post_no_bills_colombobold;
 	font-size:40px;
-	box-sizing:border-box;
-	color:black;
+	/* box-sizing:border-box; */
+    color:black;
+    display: inline-block;
+}
+
+.title-div {
+    display:flex;
+    align-items: center;
 }
 
 /*changing to class */
@@ -109,24 +121,29 @@ a:hover{
 	margin:0px;
 	height:80px;
 	width:37%;
-	float:right;
-	box-sizing:border-box;
+    /* float:right; */
+    box-sizing:border-box;
+    align-self: flex-end;
 }
 
 #nav-bar ul{
-	padding-top:20px;
-	list-style:none;
+    height: 100%;
+    list-style:none;
+    vertical-align: middle;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
-#nav-bar li{
+/* #nav-bar li{
 	display:inline;
 	padding-right:10px;
-}
+} */
 
 /*Format the links ONLY in navbar*/
 #nav-bar a{
 	font-size:18px;
-	padding-right:20px;
+	/* padding-right:20px; */
 }
 
 /*Formatting the players*/
@@ -142,7 +159,7 @@ a:hover{
 .playerImage{
 	max-width:100%;
 	height:auto;
-	text-align
+	/* text-align */
 }
 
 .fixed{
@@ -173,16 +190,16 @@ a:hover{
     text-align: center;
 }
 
-        .row:after {
+.row:after {
     content: "";
     display: table;
     clear: both;
 }
 
  .header{
-            float: none
-            text-align: center;
-        }
+    float: none;
+    text-align: center;
+}
 
 .news h2{
     text-align: center
@@ -375,3 +392,8 @@ li.pawn{
   }
 }
    
+@media only screen and (min-width: 1280px) {
+    .container, .header {
+      width: 1024px;
+    }
+  }


### PR DESCRIPTION
- For screens larger than 1280px, the container stays the same width instead of 80% (to remove the awkward whitespace on the cover photo)
- Style nav bar using flexbox instead of floats
- Remove some inline styles
- Hover social media links only transforms the logo, not the entire div

I submitted a PR to the old repo first, so I just copied all my changes over in one commit. Blame Isaac 😠 Also, check out [Hover.css](http://ianlunn.github.io/Hover/) for simple just-add-water hover transformations!